### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,16 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Block zbw key request
 RUN mkdir -p /etc/zbw/flags && touch /etc/zbw/flags/no_connection
 
+# Install dependencies
 RUN apt-get update && \
     apt-get install -qqy --no-install-recommends \
-    ca-certificates curl \
-    wget procps gpg iproute2 openssh-client openssh-server sudo logrotate && \
+    ca-certificates curl wget procps gpg iproute2 \
+    openssh-client openssh-server sudo logrotate && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# 🔑 Add updated Z-Wave.Me repo key
+RUN curl -fsSL https://repo.z-wave.me/z-way/raspbian/Release.key | gpg --dearmor -o /usr/share/keyrings/z-way.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/z-way.gpg] https://repo.z-wave.me/z-way/raspbian bullseye main" > /etc/apt/sources.list.d/z-way.list
 
 # Install z-way-server
 RUN wget -q -O - https://storage.z-wave.me/Z-Way-Install | bash -e && \
@@ -29,4 +34,4 @@ RUN chmod +x /opt/z-way-server/run.sh
 
 EXPOSE 8083
 
-CMD /opt/z-way-server/run.sh
+CMD ["/opt/z-way-server/run.sh"]


### PR DESCRIPTION
#14 This PR updates the Dockerfile to fetch and use the latest Z-Wave.Me Release.key. The old signing key had expired, causing apt-get update to fail during build. With this change, the build works again and installs Z-Way-Server successfully 